### PR TITLE
several improvements to CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,52 +1,45 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.26)
 project(py VERSION 0.1.0 LANGUAGES C CXX)
 
+include(CMakePrintHelpers)
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH 1)
 
-# path to pythonX.X.so (e.g python3.10.so)
-if(NOT PYTHON_SHARED_LIB_PATH)
-    set(PYTHON_SHARED_LIB_PATH "/usr/lib64")
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development NumPy)
+if(VERBOSE)
+    cmake_print_variables(Python3_INCLUDE_DIRS)
+    cmake_print_variables(Python3_NumPy_INCLUDE_DIRS)
 endif()
 
-# path search by puredata for externals (preferences>edit preferences...>paths in new pd versions)
-if(NOT PATH_TO_PD_EXTERNALS)
-    set(PATH_TO_PD_EXTERNALS "~/Documents/Pd/externals")
+# TODO: make a FindPd.cmake find module to address the following PD_* items:
+
+execute_process(
+    COMMAND "${Python3_EXECUTABLE}" -c "import platform; print('.pd_' + platform.system().lower())"
+    OUTPUT_VARIABLE PD_EXTERNAL_SUFFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(VERBOSE)
+    cmake_print_variables(PD_EXTERNAL_SUFFIX)
 endif()
 
-# path to libpd source files 
-if(NOT PD_SOURCE_PATH)
-    set(PD_SOURCE_PATH /usr/local/pd/src)
+set(PD_EXTERNALS_PATH "~/Documents/Pd/externals" CACHE PATH "Pd externals path")
+
+if(UNIX AND NOT APPLE)
+    set(PD_SOURCE_PATH_DEFAULT /usr/local/pd/src)
+elseif(UNIX AND APPLE)
+    set(PD_SOURCE_PATH_DEFAULT /Applications/Pd-0.54-0.app/Contents/Resources/src)
+elseif(WIN32)
+    set(PD_SOURCE_PATH_DEFAULT c:/pd/src)
 endif()
+set(PD_SOURCE_PATH ${PD_SOURCE_PATH_DEFAULT} CACHE PATH "Pd src path")
 
-# path to flext source files ; default is assumed py/pyext and flext repos have been cloned in a common parent directory
-if(NOT FLEXT_SOURCE_PATH)
-    set(FLEXT_SOURCE_PATH ../flext/source)
-endif()
+set(STRIP_TARGET OFF CACHE BOOL "Strip unneeded symbols from compiled library (saves some disk space)")
 
-# path to python source files (can be found by running `sudo find / -iname "Python.h"`)
-if(NOT PYTHON_SOURCE_PATH)
-    set(PYTHON_SOURCE_PATH /usr/include/python3.10)
-endif()
+set(FLEXT_SOURCE_PATH ../flext/source CACHE PATH "Flext source path")
+set(FLEXT_BUILD_TYPE SINGLE CACHE STRING "Flext build type")
+set_property(CACHE FLEXT_BUILD_TYPE PROPERTY STRINGS "SINGLE" "SHARED" "MULTI")
 
-# your python version
-if(NOT PYTHON_VERSION)
-    set(PYTHON_VERSION 3.10)
-endif()
-
-# flext build
-if(NOT FLEXT_BUILD_TYPE)
-    set(FLEXT_BUILD_TYPE SINGLE)
-endif()
-
-include(CMakePrintHelpers)
-cmake_print_variables(PYTHON_SOURCE_PATH)
-set(CMAKE_INSTALL_RPATH ${PYTHON_SHARED_LIB_PATH})
-set(CMAKE_BUILD_RPATH ${PYTHON_SHARED_LIB_PATH})
-# ---------------------------------------------- #
-# BUILDING OBJECT FILES
-
-add_library(objects OBJECT 
+add_library(objects OBJECT
     source/bound.cpp
     source/clmeth.cpp
     source/main.cpp
@@ -64,57 +57,46 @@ add_library(objects OBJECT
     source/pysymbol.cpp
     source/register.cpp)
 
-target_compile_options(objects PRIVATE -DPD -DUNIX -O3 -Wl,--trace -fPIC -fcheck-new -DFLEXT_INLINE -DFLEXT_ATTRIBUTES=1 -Wall -Wextra -Wshadow -Winline -Wstrict-aliasing -ffast-math -funroll-loops -fomit-frame-pointer -march=core2 -mfpmath=sse -msse -msse2 -msse3)
-
-# add flext flag depending on chosen build type
+target_compile_definitions(objects PRIVATE PD)
+target_compile_definitions(objects PRIVATE FLEXT_INLINE)
+target_compile_definitions(objects PRIVATE FLEXT_ATTRIBUTES=1)
 if(FLEXT_BUILD_TYPE STREQUAL MULTI)
-    message("setting threads")
-    target_compile_options(objects PRIVATE -DFLEXT_THREADS)
-elseif(FLEXT_BUILD_TYPE STREQUAL SHARED) 
-    target_compile_options(objects PRIVATE -DFLEXT_SHARED)
+    target_compile_definitions(objects PRIVATE FLEXT_THREADS)
+elseif(FLEXT_BUILD_TYPE STREQUAL SHARED)
+    target_compile_definitions(objects PRIVATE FLEXT_SHARED)
 endif()
-
-target_include_directories(objects PRIVATE
-    ${PD_SOURCE_PATH}
-    ${FLEXT_SOURCE_PATH}
-    ${PYTHON_SOURCE_PATH})
-
-target_link_libraries(objects PRIVATE -lpython${PYTHON_VERSION})
+if(UNIX)
+    target_compile_definitions(objects PRIVATE UNIX)
+endif()
+target_compile_options(objects PRIVATE -O3 -Wl,--trace -fPIC -fcheck-new -Wall -Wextra -Wshadow -Winline -Wstrict-aliasing -ffast-math -funroll-loops -fomit-frame-pointer)
+target_include_directories(objects PRIVATE ${PD_SOURCE_PATH})
+target_include_directories(objects PRIVATE ${FLEXT_SOURCE_PATH})
+target_link_libraries(objects PRIVATE Python3::Python Python3::NumPy)
 
 # ---------------------------------------------- #
 # BUILDING PD EXTERNAL PY/PYEXT
 
 add_library(${PROJECT_NAME} SHARED $<TARGET_OBJECTS:objects>)
-
 target_compile_options(${PROJECT_NAME} PRIVATE -rdynamic -shared -fPIC -Wl,-rpath,"\$ORIGIN",--enable-new-dtags)
-
-target_link_directories(${PROJECT_NAME} PRIVATE /usr/local/lib)
-target_link_directories(${PROJECT_NAME} PRIVATE ${PYTHON_SHARED_LIB_PATH})
-
 target_link_libraries(${PROJECT_NAME}
-    PRIVATE -lc 
-    PRIVATE -lm 
+    PRIVATE -lc
+    PRIVATE -lm
     PRIVATE -lstdc++
-    PRIVATE -lpython${PYTHON_VERSION})
-
-if(FLEXT_BUILD_TYPE STREQUAL SHARED) 
+)
+target_link_libraries(${PROJECT_NAME} PRIVATE Python3::Python Python3::NumPy)
+if(FLEXT_BUILD_TYPE STREQUAL SHARED)
     target_compile_options(${PROJECT_NAME} PRIVATE lflext-pd)
 endif()
-
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
+set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX "${PD_EXTERNAL_SUFFIX}")
 
-set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".pd_linux")
+if(STRIP_TARGET)
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+    COMMAND strip --strip-unneeded ${CMAKE_BINARY_DIR}/${PROJECT_NAME}${PD_EXTERNAL_SUFFIX}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT "Stripping file..."
+    )
+endif()
 
-# stripping file to make it lighter 
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-COMMAND strip --strip-unneeded ${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pd_linux
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Stripping file..."
-)
-
-# copying file to Pd externals directory
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-COMMAND mkdir -p ${PATH_TO_PD_EXTERNALS}/${PROJECT_NAME} && cp ${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pd_linux ${PATH_TO_PD_EXTERNALS}/${PROJECT_NAME}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Copying file to Pd externals directory..."
-)
+# install to Pd externals directory (run `cmake --install <build-dir>` to install)
+install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}${PD_EXTERNAL_SUFFIX} DESTINATION ${PD_EXTERNALS_PATH}/${PROJECT_NAME})


### PR DESCRIPTION
 - define cache variables instead of plain variable for user-configurable options; those will display nicely in any CMake gui and are self-documenting;
 - use Python3 module instead of hardcoded paths to python/numpy;
 - try to automatically determine the shared library suffix (e.g.: .pd_darwin) using Python's `platform` module (note: I tested this only on Darwin);
 - add a STRIP_TARGET option to make `strip` optional; strip fails on Darwin, probably because some GNU-specific switch has been used;
 - removed some architecture-specific options which caused build to fail on arm64; those options should anyway not be hardcoded via target_compile_options() but rather set into the specific CMAKE_* variable (e.g. `CMAKE_CXX_FLAGS`, or `CMAKE_CXX_FLAGS_RELEASE`);
 - refactored some cpp options into the proper CMake commands;
 - removed the POST_BUILD `mkdir` && `cp` command, and used the more appropriate CMake `install(...)` command.